### PR TITLE
feat(city): 优化城市系统中的人员推荐和排序功能

### DIFF
--- a/Project/Assets/Sango/Scripts/Game/System/City/CityCreateItems.cs
+++ b/Project/Assets/Sango/Scripts/Game/System/City/CityCreateItems.cs
@@ -52,6 +52,61 @@ namespace Sango.Core.Player
             base.OnEnter();
         }
 
+        /// <summary>
+        /// 创建按指定特性优先的武将排序规则。
+        /// 特性武将排在前面，同特性状态下保持原有列表顺序。
+        /// </summary>
+        /// <param name="featureId">特性编号。</param>
+        /// <returns>能将拥有指定特性的武将排在前面的排序标题。</returns>
+        private static PersonSortFunction.SortTitle CreateFeaturePrioritySort(int featureId)
+        {
+            PersonSortFunction.SortTitle sortTitle = PersonSortFunction.GetSortByFeatrueId(featureId);
+            sortTitle.personSortFunc = (a, b) => b.HasFeatrue(featureId).CompareTo(a.HasFeatrue(featureId));
+            return sortTitle;
+        }
+
+        /// <summary>创建生产兵装选择器排序：特性武将优先，组内按智力倒序。</summary>
+        public ObjectSortTitle GetProductionPersonSortTitle()
+        {
+            int featureId = GetProductionFeatureId();
+            PersonSortFunction.SortTitle sortTitle = CreateFeaturePrioritySort(featureId);
+            sortTitle.personSortFunc = (a, b) =>
+            {
+                // 先将能直接提升当前兵装生产效果的特性武将排在前面，再比较智力。
+                int featureCompare = b.HasFeatrue(featureId).CompareTo(a.HasFeatrue(featureId));
+                return featureCompare != 0 ? featureCompare : b.Intelligence.CompareTo(a.Intelligence);
+            };
+            return sortTitle;
+        }
+
+        /// <summary>按当前兵装对应特性和智力倒序返回默认推荐武将，最多返回三人。</summary>
+        public Person[] GetRecommendedCreatePersons()
+        {
+            List<Person> persons = new List<Person>(TargetCity.freePersons);
+            ObjectSortTitle sortTitle = GetProductionPersonSortTitle();
+            // 默认指派与手动选择器使用同一比较器，避免两处推荐结果不一致。
+            persons.Sort((a, b) => sortTitle.Sort(a, b));
+            if (persons.Count > 3)
+                persons.RemoveRange(3, persons.Count - 3);
+            return persons.ToArray();
+        }
+
+        /// <summary>根据当前生产的兵装仓储类型取得其对应的生产增益特性编号。</summary>
+        private int GetProductionFeatureId()
+        {
+            if (CurSelectedItemType == null || CurSelectedItemType.itemType == null)
+                return 81;
+            switch ((ItemStoreKindType)CurSelectedItemType.itemType.storeKind)
+            {
+                // 枪、戟、弩默认使用能吏；其余类型按实际生产加成特性切换。
+                case ItemStoreKindType.Horse: return 82;
+                case ItemStoreKindType.Helepolis:
+                case ItemStoreKindType.Catapult: return 83;
+                case ItemStoreKindType.Boat: return 84;
+                default: return 81;
+            }
+        }
+
         protected virtual void InitItem()
         {
             ItemTypes.Clear();
@@ -146,7 +201,7 @@ namespace Sango.Core.Player
         public override void RecommandPersonList()
         {
             personList.Clear();
-            Person[] people = ForceAI.CounsellorRecommendCreateItems(TargetCity.freePersons);
+            Person[] people = GetRecommendedCreatePersons();
             if (people != null)
             {
                 for (int i = 0; i < people.Length; ++i)

--- a/Project/Assets/Sango/Scripts/Game/System/City/CityRecruitTroops.cs
+++ b/Project/Assets/Sango/Scripts/Game/System/City/CityRecruitTroops.cs
@@ -18,6 +18,13 @@ namespace Sango.Core.Player
             windowName = "window_city_recruit_troops";
         }
 
+        /// <summary>场景数据就绪后创建名声特性列，避免构造系统时访问未初始化的场景。</summary>
+        public override void OnEnter()
+        {
+            customTitleList[1] = CreateRecruitPersonSortTitle();
+            base.OnEnter();
+        }
+
         public override bool IsValid
         {
             get
@@ -34,19 +41,36 @@ namespace Sango.Core.Player
             return TargetCity.JobRecruitTroop(personList.ToArray(), true);
         }
 
+        /// <summary>按名声优先、魅力倒序自动推荐最多三名征兵武将。</summary>
         public override void RecommandPersonList()
         {
             personList.Clear();
-            Person[] people = ForceAI.CounsellorRecommendRecruitTroop(TargetCity.freePersons);
+            List<Person> people = new List<Person>(TargetCity.freePersons);
+            // 名声特性直接提高征兵数量，因此优先于魅力参与排序。
+            people.Sort((a, b) => CreateRecruitPersonSortTitle().Sort(a, b));
+            if (people.Count > 3) people.RemoveRange(3, people.Count - 3);
             if (people != null)
             {
-                for (int i = 0; i < people.Length; ++i)
+                for (int i = 0; i < people.Count; ++i)
                 {
                     Person p = people[i];
                     if (p != null)
                         personList.Add(p);
                 }
             }
+        }
+
+        /// <summary>创建征兵专用排序列：名声优先，同组内按魅力倒序。</summary>
+        private static PersonSortFunction.SortTitle CreateRecruitPersonSortTitle()
+        {
+            PersonSortFunction.SortTitle sortTitle = PersonSortFunction.GetSortByFeatrueId(80);
+            sortTitle.personSortFunc = (a, b) =>
+            {
+                // 先比较名声特性，确保具有征兵加成的武将始终位于列表前部。
+                int featureCompare = b.HasFeatrue(80).CompareTo(a.HasFeatrue(80));
+                return featureCompare != 0 ? featureCompare : b.Glamour.CompareTo(a.Glamour);
+            };
+            return sortTitle;
         }
 
         public override void DoJob()

--- a/Project/Assets/Sango/Scripts/Game/System/City/CityTrainTroops.cs
+++ b/Project/Assets/Sango/Scripts/Game/System/City/CityTrainTroops.cs
@@ -18,6 +18,30 @@ namespace Sango.Core.Player
             windowName = "window_city_train_troops";
         }
 
+        /// <summary>进入训练时将武力列设置为默认倒序排序列。</summary>
+        public override void OnEnter()
+        {
+            customTitleList[1] = CreateTrainPersonSortTitle();
+            base.OnEnter();
+        }
+
+        /// <summary>复制武力展示列并改写比较器，避免改变全局共享的武力排序规则。</summary>
+        private static PersonSortFunction.SortTitle CreateTrainPersonSortTitle()
+        {
+            PersonSortFunction.SortTitle sortTitle = PersonSortFunction.SortByStrength;
+            sortTitle = new PersonSortFunction.SortTitle
+            {
+                name = sortTitle.name,
+                width = sortTitle.width,
+                valueGetCall = sortTitle.valueGetCall,
+                valueObjGet = sortTitle.valueObjGet,
+                valueObjSet = sortTitle.valueObjSet,
+                // 训练收益以武力为关联属性，数值高的武将优先显示和选择。
+                personSortFunc = (a, b) => b.Strength.CompareTo(a.Strength)
+            };
+            return sortTitle;
+        }
+
         protected override bool MenuCanShow()
         {
             return true;
@@ -40,13 +64,17 @@ namespace Sango.Core.Player
             return TargetCity.JobTrainTroops(personList.ToArray(), true);
         }
 
+        /// <summary>按武力倒序自动推荐最多三名训练武将。</summary>
         public override void RecommandPersonList()
         {
             personList.Clear();
-            Person[] people = ForceAI.CounsellorRecommendTrainTroops(TargetCity.freePersons);
+            List<Person> people = new List<Person>(TargetCity.freePersons);
+            // 与选择器的默认武力倒序保持一致。
+            people.Sort((a, b) => b.Strength.CompareTo(a.Strength));
+            if (people.Count > 3) people.RemoveRange(3, people.Count - 3);
             if (people != null)
             {
-                for (int i = 0; i < people.Length; ++i)
+                for (int i = 0; i < people.Count; ++i)
                 {
                     Person p = people[i];
                     if (p != null)

--- a/Project/Assets/Sango/Scripts/Game/System/City/CityTransport.cs
+++ b/Project/Assets/Sango/Scripts/Game/System/City/CityTransport.cs
@@ -60,19 +60,22 @@ namespace Sango.Core.Player
             TargetTroop.CalculateAttribute(Scenario.Cur);
         }
 
+        /// <summary>初始化运输部队，并在场景数据就绪后创建搬运特性排序列。</summary>
         public override void OnEnter()
         {
+            // 特性标题依赖 Scenario.Cur，必须延迟到进入运输命令后再生成。
+            customTitleList[1] = CreateTransportPersonSortTitle();
             personList.Clear();
             TargetTroop = new Troop();
             Scenario scenario = Scenario.Cur;
-            Person[] persons = ForceAI.CounsellorRecommendTransportTroop(TargetCity.freePersons);
-            Person leader = persons[0];
+            // 默认主将与手动选择器均按搬运优先规则确定。
+            Person[] persons = GetRecommendedTransportPersons();
+            Person leader = persons.Length > 0 ? persons[0] : null;
 
             if (leader != null)
                 personList.Add(leader);
 
             TargetTroop.morale = TargetCity.morale;
-            //TargetTroop.MaxMorale = TargetCity.MaxMorale;
             TargetTroop.energy = TargetCity.energy;
             TargetTroop.Leader = leader;
             TargetTroop.Member1 = null;
@@ -87,6 +90,29 @@ namespace Sango.Core.Player
             TargetTroop.missionType = (int)MissionType.TroopTransformGoodsToCity;
             TargetTroop.CalculateAttribute(Scenario.Cur);
             Window.Instance.Open(windowName);
+        }
+
+        /// <summary>创建运输专用排序列：搬运优先，同组内按运输能力倒序。</summary>
+        private static PersonSortFunction.SortTitle CreateTransportPersonSortTitle()
+        {
+            PersonSortFunction.SortTitle sortTitle = PersonSortFunction.GetSortByFeatrueId(8);
+            sortTitle.personSortFunc = (a, b) =>
+            {
+                // 搬运特性提高输送部队移动力，应优先于基础运输能力。
+                int featureCompare = b.HasFeatrue(8).CompareTo(a.HasFeatrue(8));
+                return featureCompare != 0 ? featureCompare : b.MilitaryAbility.CompareTo(a.MilitaryAbility);
+            };
+            return sortTitle;
+        }
+
+        /// <summary>按运输选择器的排序规则推荐最多三名武将。</summary>
+        private Person[] GetRecommendedTransportPersons()
+        {
+            List<Person> persons = new List<Person>(TargetCity.freePersons);
+            // 复用展示排序，保证自动推荐与玩家手动选择的优先级一致。
+            persons.Sort((a, b) => CreateTransportPersonSortTitle().Sort(a, b));
+            if (persons.Count > 3) persons.RemoveRange(3, persons.Count - 3);
+            return persons.ToArray();
         }
 
         public void MakeTroop()

--- a/Project/Assets/Sango/Scripts/GameStart.cs
+++ b/Project/Assets/Sango/Scripts/GameStart.cs
@@ -163,7 +163,7 @@ public class GameStart : MonoBehaviour
         /// </summary>
 #if UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
         Game.Instance.Init(this, Platform.PlatformName.Mac);
-#elif UNITY_STANDALONE_WIN
+#elif UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
         Game.Instance.Init(this, Platform.PlatformName.Window);
 #elif UNITY_ANDROID
         Game.Instance.Init(this, Platform.PlatformName.Android);

--- a/Project/Assets/Sango/Scripts/UI/City/UICityCreateItems.cs
+++ b/Project/Assets/Sango/Scripts/UI/City/UICityCreateItems.cs
@@ -71,6 +71,7 @@ using Sango.Core; namespace Sango.UI
             }
         }
 
+        /// <summary>切换兵装类型，并按该兵装对应特性和智力重新生成默认指派。</summary>
         public void OnSelectItemType(UIBuildingTypeItem buildingTypeItem)
         {
             if (currentSystem.CurSelectedItemTypeIndex >= 0)
@@ -82,7 +83,8 @@ using Sango.Core; namespace Sango.UI
             CityCreateItems.ItemTypeInfo curItemType = currentSystem.ItemTypes[buildingTypeItem.index];
             currentSystem.CurSelectedItemType = curItemType;
             currentSystem.TargetBuilding = curItemType.targetBuilding;
-            Person[] builder = ForceAI.CounsellorRecommendCreateItems(currentSystem.TargetCity.freePersons);
+            // 每种兵装的增益特性不同，切换后必须同步刷新默认武将。
+            Person[] builder = currentSystem.GetRecommendedCreatePersons();
             currentSystem.personList.Clear();
             if (builder == null || builder.Length == 0)
             {
@@ -144,10 +146,15 @@ using Sango.Core; namespace Sango.UI
             }
         }
 
+        /// <summary>打开兵装生产武将选择器，展示名称、智力和当前兵装关联特性列。</summary>
         public void OnSelectPerson()
         {
             GameSystem.GetSystem<PersonSelectSystem>().Start(currentSystem.TargetCity.freePersons,
-                currentSystem.personList, 3, OnPersonChange, currentSystem.customTitleList, currentSystem.customTitleName);
+                currentSystem.personList, 3, OnPersonChange,
+                // 默认按特性优先、智力倒序；智力列保留供玩家核对。
+                new List<ObjectSortTitle> { PersonSortFunction.SortByName, PersonSortFunction.SortByIntelligence,
+                    currentSystem.GetProductionPersonSortTitle() },
+                currentSystem.customTitleName, 2);
         }
 
         public void OnSure()

--- a/Project/Assets/Sango/Scripts/UI/City/UICityRecruitTroops.cs
+++ b/Project/Assets/Sango/Scripts/UI/City/UICityRecruitTroops.cs
@@ -57,10 +57,11 @@ using Sango.Core; namespace Sango.UI
             currentSystem.Exit();
         }
 
+        /// <summary>打开征兵选择器，默认使用名声优先、魅力倒序的排序列。</summary>
         public void OnSelectPerson()
         {
             GameSystem.GetSystem<PersonSelectSystem>().Start(currentSystem.TargetCity.freePersons,
-               currentSystem.personList, 3, OnPersonChange, currentSystem.customTitleList, currentSystem.customTitleName);
+               currentSystem.personList, 3, OnPersonChange, currentSystem.customTitleList, currentSystem.customTitleName, 1);
         }
 
         public virtual void OnPersonChange(List<Person> personList)

--- a/Project/Assets/Sango/Scripts/UI/City/UICityTransport.cs
+++ b/Project/Assets/Sango/Scripts/UI/City/UICityTransport.cs
@@ -285,10 +285,11 @@ namespace Sango.UI
             UpdateContent();
         }
 
+        /// <summary>打开运输选择器，默认使用搬运特性优先的排序列。</summary>
         public void OnSelectPerson()
         {
             GameSystem.GetSystem<PersonSelectSystem>().Start(cityTransportSys.TargetCity.freePersons,
-                cityTransportSys.personList, 3, OnPersonChange, cityTransportSys.customTitleList, cityTransportSys.customTitleName);
+                cityTransportSys.personList, 3, OnPersonChange, cityTransportSys.customTitleList, cityTransportSys.customTitleName, 1);
         }
 
         public void OnSlecteMax()


### PR DESCRIPTION
- 在 CityCreateItems 中实现按特性优先的武将排序规则，支持生产兵装时的智能推荐
- 为 CityRecruitTroops 添加基于魅力属性的招募人员排序功能
- 在 CityTrainTroops 中集成力量属性排序的训练人员推荐逻辑
- 为 CityTransport 实现运输任务的人员特性排序和推荐功能
- 更新 UI 组件以使用新的排序算法替代原有的 AI 推荐系统
- 修复平台检测逻辑，确保 Windows 编辑器下的正确初始化
- 统一各城市系统的人员选择界面排序参数配置